### PR TITLE
Host harp JSON schemas

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,3 +35,6 @@
 	path = protocol
 	url = https://github.com/harp-tech/protocol.git
 	branch = doc-generation
+[submodule "reflex-generator"]
+	path = draft-01
+	url = https://github.com/harp-tech/reflex-generator.git

--- a/docfx.json
+++ b/docfx.json
@@ -54,6 +54,7 @@
           "protocol/Assets/**",
           "protocol/Logo/*.svg",
           "protocol/*.pdf",
+          "draft-01/schema/*.json",
           "images/**",
           "workflows/**"
         ]


### PR DESCRIPTION
This PR adds [reflex-generator](https://github.com/harp-tech/reflex-generator/tree/main/schema) as a submodule and configures DocFX to host all schemas as a resource. The name of the submodule folder can be used for semver of the release. As a first test we host the original schemas under `draft-01`.