### PR TITLE
Fix unnecessary GitHub Actions version specificity, update old actions, and update to modern GitHub Pages deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# Builds and publishes the documentation website to gh-pages branch
+# Builds and publishes the documentation website
 name: Build docs
 
 on:
@@ -6,17 +6,26 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: build
+  cancel-in-progress: true
+
+permissions:
+  # Both required by actions/deploy-pages
+  pages: write
+  id-token: write
+
 jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Checkout
         with:
           submodules: recursive
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v3.2.0
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.x
 
@@ -24,8 +33,8 @@ jobs:
         run: .\build.ps1
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
-      
+        uses: microsoft/setup-msbuild@v2
+
       - name: Restore NuGet Packages
         run: msbuild -t:restore src\harp\Bonsai.Harp.sln
 
@@ -34,15 +43,9 @@ jobs:
 
       - name: Build Documentation
         run: dotnet docfx docfx.json
-          
-      - name: Checkout gh-pages
-        uses: actions/checkout@v2
-        with:
-          ref: gh-pages
-          path: gh-pages
-      - name: Publish to github pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _site
-          force_orphan: true
+
+      - name: Upload GitHub Pages Artifact
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
**Before merging this PR:** Go to [the GitHub Pages settings](../settings/pages) for this repo and change the build/deployment source to "GitHub Actions".

------------

This PR removes unnecessary version specificity for actions used in GitHub Actions workflows in this repository. This reflects best practices and avoids upcoming issues with `actions/setup-dotnet`, see [this issue](https://github.com/bonsai-rx/bonsai/issues/2091) for details.

While I was at it I migrated the docs workflow to use the modern method for GitHub Pages deployment, and updated other actions as appropriate.