### PR TITLE
Improve API navigation and render members as separate pages

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.78.2",
+      "version": "2.78.3",
       "commands": [
         "docfx"
       ],

--- a/docfx.json
+++ b/docfx.json
@@ -16,7 +16,8 @@
       ],
       "dest": "api",
       "filter": "filter.yml",
-      "enumSortOrder": "declaringOrder"
+      "enumSortOrder": "declaringOrder",
+      "memberLayout": "separatePages"
     }
   ],
   "build": {

--- a/toc.yml
+++ b/toc.yml
@@ -1,6 +1,6 @@
-- name: Manual
+- name: Documentation
   href: articles/
-- name: Reference
+- name: API
   href: api/
 - name: Tutorials
   href: tutorials/


### PR DESCRIPTION
The separate member pages layout makes both navigation hierarchy and listing of individual properties in each class easier to digest with a summary table at the top.

Incidentally this also makes all devices in the API section visible when landing on the page, as the first expanded tree view item has only three nodes in it, so we can now see the list of all devices without collapsing nodes.